### PR TITLE
Add support for boards with different name of serial USB connection

### DIFF
--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -16,6 +16,7 @@ void ArduinoLowPowerClass::idle(uint32_t millis) {
 }
 
 void ArduinoLowPowerClass::sleep() {
+	/* remove for Adafruit Feather M0
 	bool restoreUSBDevice = false;
 	if (SerialUSB) {
 		USBDevice.standby();
@@ -23,12 +24,15 @@ void ArduinoLowPowerClass::sleep() {
 		USBDevice.detach();
 		restoreUSBDevice = true;
 	}
+	*/
 	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
 	__DSB();
 	__WFI();
+	/* remove for Adafruit Feather M0
 	if (restoreUSBDevice) {
 		USBDevice.attach();
 	}
+	*/
 }
 
 void ArduinoLowPowerClass::sleep(uint32_t millis) {

--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -16,23 +16,19 @@ void ArduinoLowPowerClass::idle(uint32_t millis) {
 }
 
 void ArduinoLowPowerClass::sleep() {
-	/* remove for Adafruit Feather M0
 	bool restoreUSBDevice = false;
-	if (SerialUSB) {
+	if (SERIAL_PORT_USBVIRTUAL) {
 		USBDevice.standby();
 	} else {
 		USBDevice.detach();
 		restoreUSBDevice = true;
 	}
-	*/
 	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
 	__DSB();
 	__WFI();
-	/* remove for Adafruit Feather M0
 	if (restoreUSBDevice) {
 		USBDevice.attach();
 	}
-	*/
 }
 
 void ArduinoLowPowerClass::sleep(uint32_t millis) {


### PR DESCRIPTION
I discovered that I couldn't use this library for the Adafruit Feather M0 which is a SAMD21 board. The reason was that the USB connection is named *Serial1* and not *SerialUSB* as for the Arduino Zero. I figured it would be best to use the SERIAL_PORT_USBVIRTUAL define that is set in the board files. This way the library automatically uses the correct port.