### PR TITLE
[TEST] Disable USB on sleep

### DIFF
--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -17,18 +17,14 @@ void ArduinoLowPowerClass::idle(uint32_t millis) {
 
 void ArduinoLowPowerClass::sleep() {
 	bool restoreUSBDevice = false;
-	if (SERIAL_PORT_USBVIRTUAL) {
-		USBDevice.standby();
-	} else {
-		USBDevice.detach();
-		restoreUSBDevice = true;
-	}
+	USBDevice.detach();
+	USBDevice.end();
+	USBDevice.standby();
 	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
 	__DSB();
 	__WFI();
-	if (restoreUSBDevice) {
-		USBDevice.attach();
-	}
+	USBDevice.init();
+	USBDevice.attach();
 }
 
 void ArduinoLowPowerClass::sleep(uint32_t millis) {


### PR DESCRIPTION
This commit tries to solve https://github.com/arduino-libraries/ArduinoLowPower/issues/7 ; must be used in conjuction with https://github.com/arduino/ArduinoCore-samd/pull/361

Expected behaviour:
the USB core is now totally disabled during standby (eg. it cannot receive a WAKEUP from the host PC). At every other kind of wakeup (RTC/gpio) the board re-enumerate itself, as if it was the first attach(). All OS should support this cleanly, however the port name could change or the serial monitor in use could not pick up the new board. All serial monitors should be closed and reopened after a successful resume.

