### PR TITLE
wrong assumption, that `pin > PINS_COUNT` cannot yield valid pins for interrupts

### DIFF
--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -18,6 +18,7 @@ void ArduinoLowPowerClass::idle(uint32_t millis) {
 void ArduinoLowPowerClass::sleep() {
 	bool restoreUSBDevice = false;
 	if (SERIAL_PORT_USBVIRTUAL) {
+		SERIAL_PORT_USBVIRTUAL.flush();
 		USBDevice.standby();
 	} else {
 		USBDevice.detach();
@@ -28,6 +29,9 @@ void ArduinoLowPowerClass::sleep() {
 	__WFI();
 	if (restoreUSBDevice) {
 		USBDevice.attach();
+	}
+	if (SERIAL_PORT_USBVIRTUAL) {
+		SERIAL_PORT_USBVIRTUAL.clear();
 	}
 }
 

--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -57,7 +57,9 @@ void ArduinoLowPowerClass::setAlarmIn(uint32_t millis) {
 
 void ArduinoLowPowerClass::attachInterruptWakeup(uint32_t pin, voidFuncPtr callback, uint32_t mode) {
 
-	if (pin > PINS_COUNT) {
+    EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
+
+    if (in == NOT_AN_INTERRUPT || in == EXTERNAL_INT_NMI) {
 		// check for external wakeup sources
 		// RTC library should call this API to enable the alarm subsystem
 		switch (pin) {
@@ -68,10 +70,6 @@ void ArduinoLowPowerClass::attachInterruptWakeup(uint32_t pin, voidFuncPtr callb
 		}
 		return;
 	}
-
-	EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
-	if (in == NOT_AN_INTERRUPT || in == EXTERNAL_INT_NMI)
-    		return;
 
 	//pinMode(pin, INPUT_PULLUP);
 	attachInterrupt(pin, callback, mode);


### PR DESCRIPTION
e.g. the `Arduino MKRFOX1200` has the `SIGFOX_EVENT_PIN` on 33, whereas `PINS_COUNT` yields 26, which leads to the SigFox library being unable to register interrupts for wakeups based on those events.

Compare with: https://github.com/arduino-libraries/SigFox/blob/master/src/SigFox.cpp#L170

This pull request changes the logic to detect invalid pins slightly, so that using the `SIGFOX_EVENT_PIN` for interrupts is now possible.

**Edit**: I have appended something else. This [commit](https://github.com/polygamma/ArduinoLowPower/commit/d39fa7ed5e5c71cf771087865f8c7fe5406dcb2a) together with [this](https://github.com/polygamma/ArduinoCore-samd/commit/037b770928c9632f91e5e3f793eb0f1fc021915a) also fixes [this](https://github.com/arduino-libraries/ArduinoLowPower/issues/7), the problems with Serial not working after sleeping.