### PR TITLE
wonky serial connection after wakeup

### DIFF
--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -18,6 +18,7 @@ void ArduinoLowPowerClass::idle(uint32_t millis) {
 void ArduinoLowPowerClass::sleep() {
 	bool restoreUSBDevice = false;
 	if (SERIAL_PORT_USBVIRTUAL) {
+		SERIAL_PORT_USBVIRTUAL.flush();
 		USBDevice.standby();
 	} else {
 		USBDevice.detach();
@@ -28,6 +29,9 @@ void ArduinoLowPowerClass::sleep() {
 	__WFI();
 	if (restoreUSBDevice) {
 		USBDevice.attach();
+	}
+	if (SERIAL_PORT_USBVIRTUAL) {
+		SERIAL_PORT_USBVIRTUAL.clear();
 	}
 }
 


### PR DESCRIPTION
Using Arch Linux and a MKR FOX 1200, the following codesnippet yields unwanted output:

```
#include "ArduinoLowPower.h" // https://www.arduino.cc/en/Reference/ArduinoLowPower
#include "RTCZero.h" // https://www.arduino.cc/en/Reference/RTC

/*
 * initial setup, will be run once at the start of the whole routine
 */
void setup() {
  // init serial connection
  Serial.begin(9600);
  while (!Serial) {}
  RTCZero().begin(false);
}

/*
 * will be run forever, after initial setup() call
 */
void loop() {
  Serial.println("I am being printed, because the device has not been sleeping, yet");
  
  // deep sleep of 5 seconds
  LowPower.sleep(1000 * 5);
  
  Serial.println("I am never being printed, because of a deadlock");
}
```

Expected would be:

> I am being printed, because the device has not been sleeping, yet
> I am never being printed, because of a deadlock
> I am being printed, because the device has not been sleeping, yet
> I am never being printed, because of a deadlock
> I am being printed, because the device has not been sleeping, yet
> I am never being printed, because of a deadlock
> I am being printed, because the device has not been sleeping, yet
> I am never being printed, because of a deadlock
> I am being printed, because the device has not been sleeping, yet

but I actually get:

> I am being printed, because the device has not been sleeping, yet
> 
> I am being printed, because the device has not been sleeping, yet
> I am never being printed, because of a deadlock
> I am being printed, because the device has not been sleeping, yet
> 
> I am being printed, because the device has not been sleeping, yet
> I am never being printed, because of a deadlock
> I am being printed, because the device has not been sleeping, yet

I found the cause to be laying [here](https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/USB/USBCore.cpp#L665), after the wakeup, the first "print" command times out, leading the call to end [here](https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/USB/USBCore.cpp#L681).

Allowing the Low Power library to `clear` the relevant stuff, as it is already being done [here](https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/USB/USBCore.cpp#L697), leads to the Serial connection working properly after the wakeup.

[This](https://github.com/polygamma/ArduinoCore-samd/commit/037b770928c9632f91e5e3f793eb0f1fc021915a) is the relevant commit for the USBCore to provide the needed functionality.