### PR TITLE
Reduce power consumption during sleep

### DIFF
--- a/src/ArduinoLowPower.h
+++ b/src/ArduinoLowPower.h
@@ -2,6 +2,9 @@
 #define _ARDUINO_LOW_POWER_H_
 
 #include <Arduino.h>
+#include <SERCOM.h>
+#include <Wire.h>
+#include <SPI.h>
 
 #ifdef ARDUINO_ARCH_AVR
 #error The library is not compatible with AVR boards
@@ -50,6 +53,9 @@ class ArduinoLowPowerClass {
 		}
 
 		void attachInterruptWakeup(uint32_t pin, voidFuncPtr callback, uint32_t mode);
+		void wakeOnWire(TwoWire * wire, bool intEnable);
+		void wakeOnSPI(SPIClass * spi, bool intEnable);
+		void wakeOnSerial(Uart * uart, bool intEnable);
 
 		#ifdef BOARD_HAS_COMPANION_CHIP
 		void companionLowPowerCallback(onOffFuncPtr callback) {

--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -92,6 +92,24 @@ void ArduinoLowPowerClass::attachInterruptWakeup(uint32_t pin, voidFuncPtr callb
 	NVMCTRL->CTRLB.bit.SLEEPPRM = NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val;
 }
 
+void ArduinoLowPowerClass::wakeOnWire(TwoWire * wire, bool intEnable) {
+	wire->sercom->disableWIRE();
+	wire->sercom->sercom->I2CS.CTRLA.bit.RUNSTDBY = intEnable ;
+	wire->sercom->enableWIRE();
+}
+
+void ArduinoLowPowerClass::wakeOnSPI(SPIClass * spi, bool intEnable) {
+	spi->_p_sercom->disableSPI();
+	spi->_p_sercom->sercom->SPI.CTRLA.bit.RUNSTDBY = intEnable ;
+	spi->_p_sercom->enableSPI();
+}
+
+void ArduinoLowPowerClass::wakeOnSerial(Uart * uart, bool intEnable) {
+	uart->sercom->disableUART();
+	uart->sercom->sercom->USART.CTRLA.bit.RUNSTDBY = intEnable ;
+	uart->sercom->enableUART();
+}
+
 ArduinoLowPowerClass LowPower;
 
 #endif // ARDUINO_ARCH_SAMD

--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -16,13 +16,6 @@ void ArduinoLowPowerClass::idle(uint32_t millis) {
 }
 
 void ArduinoLowPowerClass::sleep() {
-	bool restoreUSBDevice = false;
-	if (SERIAL_PORT_USBVIRTUAL) {
-		USBDevice.standby();
-	} else {
-		USBDevice.detach();
-		restoreUSBDevice = true;
-	}
 	// Disable systick interrupt:  See https://www.avrfreaks.net/forum/samd21-samd21e16b-sporadically-locks-and-does-not-wake-standby-sleep-mode
 	SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;	
 	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
@@ -30,9 +23,6 @@ void ArduinoLowPowerClass::sleep() {
 	__WFI();
 	// Enable systick interrupt
 	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;	
-	if (restoreUSBDevice) {
-		USBDevice.attach();
-	}
 }
 
 void ArduinoLowPowerClass::sleep(uint32_t millis) {


### PR DESCRIPTION
This PR adds three functions to allow for wake up sources during sleep for Wire, SPI and UART.

It is necessary to make the ArduinoLowPowerClass a friend of TwoWire, SERCOM and Uart and SPIClass classes in the ArduinoCore-samd.  I will submit a separate PR for this.

The USB standby/restore that is part of the sleep() function has been removed because it causes significant power consumption during sleep and a 10ms additional delay going to sleep.