### PR TITLE
Allow sleep durations of 1 day or longer

### DIFF
--- a/src/samd/ArduinoLowPower.cpp
+++ b/src/samd/ArduinoLowPower.cpp
@@ -56,7 +56,7 @@ void ArduinoLowPowerClass::setAlarmIn(uint32_t millis) {
 
 	uint32_t now = rtc.getEpoch();
 	rtc.setAlarmEpoch(now + millis/1000);
-	rtc.enableAlarm(rtc.MATCH_HHMMSS);
+	rtc.enableAlarm(rtc.MATCH_YYMMDDHHMMSS);
 }
 
 void ArduinoLowPowerClass::attachInterruptWakeup(uint32_t pin, voidFuncPtr callback, uint32_t mode) {


### PR DESCRIPTION
Previously, sleep durations "overflowed" at one day, resulting in a maximum sleep duration of 1 millisecond less than a day.

Demonstration sketch:
```c++
#include <ArduinoLowPower.h>

void setup() {
  pinMode(LED_BUILTIN, OUTPUT);
  LowPower.sleep(24 * 60 * 60 * 1000);
}

void loop() {
  digitalWrite(LED_BUILTIN, HIGH);
  delay(100);
  digitalWrite(LED_BUILTIN, LOW);
  delay(100);
}
```
The expected behavior of the above code is the LED should start blinking after the sleep of 24 hours ends. With the current library code, the sleep ends, and LED starts blinking, immediately.

Fixes https://github.com/arduino-libraries/ArduinoLowPower/issues/22