### PR TITLE
Use www subdomain in arduino.cc URLs

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Arduino LLC
 sentence=Power save primitives features for SAMD and nRF52 32bit boards
 paragraph=With this library you can manage the low power states of newer Arduino boards
 category=Device Control
-url=http://arduino.cc/libraries/ArduinoLowPower
+url=https://www.arduino.cc/libraries/ArduinoLowPower
 architectures=samd,nrf52
 depends=RTCZero


### PR DESCRIPTION
www.arduino.cc is Arduino's preferred url.