### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,28 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          library-manager: update
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,94 @@
+name: Compile Examples
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:samd:arduino_zero_edbg
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkr1000
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrzero
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwifi1010
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrfox1200
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwan1300
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwan1310
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrgsm1400
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrnb1500
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrvidor4000
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:nano_33_iot
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:tian
+            platforms: |
+              - name: arduino:samd
+            sketch-paths: |
+              - examples/TianStandby
+          - fqbn: arduino:nrf52:primo
+            platforms: |
+              - name: arduino:nrf52
+            sketch-paths: |
+              - examples/PrimoDeepSleep
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            - name: RTCZero
+          sketch-paths: |
+            # Sketches to compile for all boards
+            - examples/AdcWakeup
+            - examples/ExternalWakeup
+            - examples/TimedWakeup
+            # Board-specific sketches
+            ${{ matrix.board.sketch-paths }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,6 +23,10 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
+    strategy:
       fail-fast: false
 
       matrix:
@@ -92,3 +96,12 @@ jobs:
             - examples/TimedWakeup
             # Board-specific sketches
             ${{ matrix.board.sketch-paths }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arduino Low Power library
 
+[![Check Arduino status](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/check-arduino.yml)
 [![Spell Check status](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/spell-check.yml)
 
 This library allows the use of the low power features of the SAMD21 MCU. This means your battery powered projects will have a longer battery life on boards like [MKRZero](https://store.arduino.cc/usa/arduino-mkrzero), [MKR1000](https://www.arduino.cc/en/Main/ArduinoMKR1000) and [MKRFox1200](https://www.arduino.cc/en/Main/ArduinoBoardMKRFox1200).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arduino Low Power library
 
 [![Check Arduino status](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/check-arduino.yml)
+[![Compile Examples status](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/compile-examples.yml)
 [![Spell Check status](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/spell-check.yml)
 
 This library allows the use of the low power features of the SAMD21 MCU. This means your battery powered projects will have a longer battery life on boards like [MKRZero](https://store.arduino.cc/usa/arduino-mkrzero), [MKR1000](https://www.arduino.cc/en/Main/ArduinoMKR1000) and [MKRFox1200](https://www.arduino.cc/en/Main/ArduinoBoardMKRFox1200).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Arduino Low Power library
 
+[![Spell Check status](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoLowPower/actions/workflows/spell-check.yml)
+
 This library allows the use of the low power features of the SAMD21 MCU. This means your battery powered projects will have a longer battery life on boards like [MKRZero](https://store.arduino.cc/usa/arduino-mkrzero), [MKR1000](https://www.arduino.cc/en/Main/ArduinoMKR1000) and [MKRFox1200](https://www.arduino.cc/en/Main/ArduinoBoardMKRFox1200).
 
 For more information about this library please visit us at

--- a/examples/PrimoDeepSleep/PrimoDeepSleep.ino
+++ b/examples/PrimoDeepSleep/PrimoDeepSleep.ino
@@ -4,16 +4,16 @@
   Written by Chiara Ruggeri (chiara@arduino.org)
   
   This example for the Arduino Primo board shows how to use
-  low power library to enter in power off mode and save power.
-  This mode ensure the deepest power saving mode. If you need
+  Arduino Low Power library to enter in power off mode and save power.
+  This mode ensures the deepest power saving mode. If you need
   a faster response from the board use standby function instead.
   
   Please note that once exited from the deepest sleep mode the
   board will reset (so setup will be run again).
   
   The functions enableWakeupFrom set the peripheral that will wake up
-  the board. By calling it more than once you can choose more than
-  a wakeup source.
+  the board. By calling it more than once you can choose multiple
+  wakeup sources.
   The board will be reset when it wakes up from power off.
   You can use wakeUpCause() function to find out what signals woke up
   the board if you use more than one wakeUpBy.. function.
@@ -27,7 +27,7 @@
 // Pin used to wakeup the board
 const int digitalPin = 10;
 
-// Pin used in Compatarot module to wake up the board
+// Pin used in Comparator module to wake up the board
 const int analogPin = A0;
 
 

--- a/examples/TianStandby/TianStandby.ino
+++ b/examples/TianStandby/TianStandby.ino
@@ -1,12 +1,12 @@
 /*
   TianStandby
 
-  This sketch demonstrates the usage of SAMD chip to furtherly reduce the power usage of Tian
+  This sketch demonstrates the usage of SAMD chip to further reduce the power usage of the Tian
   board. This method can be applied to any board with companion chips which expose a method 
   (via direct pin interrupt or via a command) to enter and exit standby.
-  Sleep modes allow a significant drop in the power usage of a board while it does nothing waiting for an event to happen. Battery powered application can take advantage of these modes to enhance battery life significantly.
+  Sleep modes allow a significant drop in the power usage of a board while it does nothing waiting for an event to happen. Battery powered applications can take advantage of these modes to enhance battery life significantly.
 
-  In this sketch, the internal RTC of SAMD chip will wake up the processor every 20 seconds.
+  In this sketch, the internal RTC of the SAMD chip will wake up the processor every 20 seconds.
   Before going to sleep, the SAMD chip tells the MIPS CPU to standby too.
   Please note that, if the processor is sleeping, a new sketch can't be uploaded. To overcome this, manually reset the board (usually with a single or double tap to the RESET button)
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 #######################################
-# Syntax Coloring Map For Energy Saving
+# Syntax Coloring Map For Arduino Low Power
 #######################################
 
 #######################################

--- a/src/nrf52/ArduinoLowPower.cpp
+++ b/src/nrf52/ArduinoLowPower.cpp
@@ -64,7 +64,7 @@ void ArduinoLowPowerClass::deepSleep() {
 	//this is achieved by disabling all peripheral that use it
 	NRF_UARTE0->ENABLE = UARTE_ENABLE_ENABLE_Disabled;								//disable UART
 	NRF_SAADC ->ENABLE = (SAADC_ENABLE_ENABLE_Disabled << SAADC_ENABLE_ENABLE_Pos);	//disable ADC
-	NRF_PWM0  ->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);		//disable all pwm instance
+	NRF_PWM0  ->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);		//disable all PWM instances
 	NRF_PWM1  ->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);
 	NRF_PWM2  ->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);
 	NRF_TWIM1 ->ENABLE = (TWIM_ENABLE_ENABLE_Disabled << TWIM_ENABLE_ENABLE_Pos);	//disable TWI Master
@@ -118,7 +118,7 @@ void ArduinoLowPowerClass::enableWakeupFrom(wakeup_reason peripheral, uint32_t p
 		nrf_lpcomp_config_t config={(nrf_lpcomp_ref_t)event, (nrf_lpcomp_detect_t)mode};
 		nrf_lpcomp_configure(&config);
 		if(pin<14 && pin>19)
-			return;	//no analog pin is choosen
+			return;	//no analog pin was chosen
 		nrf_lpcomp_input_select(aPin[pin-14]);
 		nrf_lpcomp_enable();
 		nrf_lpcomp_task_trigger(NRF_LPCOMP_TASK_START);


### PR DESCRIPTION
This PR provides the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/ArduinoLowPower/issues/38