### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino Low Power
 version=1.2.2
 author=Arduino
-maintainer=Arduino LLC
+maintainer=Arduino <info@arduino.cc>
 sentence=Power save primitives features for SAMD and nRF52 32bit boards
 paragraph=With this library you can manage the low power states of newer Arduino boards
 category=Device Control


### PR DESCRIPTION
Maintainer is changed from `Arduino LLC` to `Arduino <info@arduino.cc>` within the `library.properties` file. 